### PR TITLE
fix: align star button next to Hide button in results header

### DIFF
--- a/app/client/src/style.css
+++ b/app/client/src/style.css
@@ -143,9 +143,13 @@ h2 {
 
 .results-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
+  gap: 0.5rem;
+}
+
+.results-header h2 {
+  margin-right: auto;
 }
 
 .sql-display {


### PR DESCRIPTION
## Summary
- Fixed misaligned star/favorite button in the Query Results header that was appearing in the middle instead of next to the Hide button
- Replaced `justify-content: space-between` with `margin-right: auto` on the h2 element to group action buttons together on the right

## Test plan
- [ ] Load the app and run a query
- [ ] Verify the star button appears next to the Hide button on the right side of the results header
- [ ] Verify the h2 "Query Results" title remains on the left

🤖 Generated with [Claude Code](https://claude.com/claude-code)