### PR TITLE
bug: #13 - Fix download CSV button misplaced

### DIFF
--- a/.claude/commands/e2e/test_csv_download_alignment.md
+++ b/.claude/commands/e2e/test_csv_download_alignment.md
@@ -1,0 +1,32 @@
+# E2E Test: CSV Download Button Alignment
+
+Test that the CSV download button is visually grouped next to the remove button in the table header, not floating in the center.
+
+## User Story
+
+As a user
+I want the download and remove buttons to be grouped together on the right side of the table header
+So that the interface looks clean and the action buttons are easy to find
+
+## Test Steps
+
+1. Navigate to the `Application URL`
+2. Click the "Upload Data" button (`#upload-data-button`) to open the upload modal
+3. **Verify** the upload modal (`#upload-modal`) is visible
+4. Click the sample data button with `data-sample="products"` to load the Products sample data
+5. Wait for the modal to close and the schema to refresh
+6. **Verify** a `.table-item` element exists in `#tables-list` containing "products" in `.table-name`
+7. **Verify** a `.download-table-button` element is visible inside the `products` table card
+8. **Verify** the `.download-table-button` and `.remove-table-button` inside the `products` table card share the same parent element (i.e. they are siblings within a button group container that is a direct child of `.table-header`)
+9. **Verify** via bounding box that the download button's right edge is adjacent to (within 16px of) the remove button's left edge
+10. Take a screenshot of the table card header showing the buttons are grouped on the right
+11. Click the `.download-table-button` inside the `products` table card using Playwright's `waitForEvent('download')` to confirm the download still triggers
+12. **Verify** the download event fires with suggested filename `products.csv`
+13. Take a screenshot after the download was triggered
+
+## Success Criteria
+- Download button (`.download-table-button`) and remove button (`.remove-table-button`) are siblings within the same parent container
+- Both buttons are visually grouped on the right side of the table header
+- The download button's right edge is within 16px of the remove button's left edge
+- The download button still triggers a file download
+- 2 screenshots are taken

--- a/.claude/commands/e2e/test_sample_data_loading.md
+++ b/.claude/commands/e2e/test_sample_data_loading.md
@@ -1,0 +1,54 @@
+# E2E Test: Sample Data Loading
+
+Test the quick-start sample data buttons in the upload modal of the Natural Language SQL Interface application.
+
+## User Story
+
+As a new user
+I want to load pre-built sample datasets with one click
+So that I can start exploring the application without preparing my own data
+
+## Test Steps
+
+1. Navigate to the `Application URL`
+2. Take a screenshot of the initial state
+3. **Verify** the "Upload Data" button (`#upload-data-button`) is present in the `.query-controls` area
+4. Click the "Upload Data" button to open the upload modal
+5. **Verify** the upload modal (`#upload-modal`) is visible
+6. **Verify** three sample data buttons (`.sample-button`) are present inside `.sample-buttons`:
+   - "Users Data" button with `data-sample="users"`
+   - "Product Inventory" button with `data-sample="products"`
+   - "Event Analytics" button with `data-sample="events"`
+7. Take a screenshot of the upload modal showing the sample data buttons
+
+8. Click the "Users Data" sample button (`[data-sample="users"]`)
+9. Wait for the modal to close and for a `.success-message` to appear
+10. **Verify** the upload modal (`#upload-modal`) is hidden
+11. **Verify** a `.success-message` is displayed containing "users" and "created successfully"
+12. **Verify** "users" appears as a `.table-name` in the `#tables-list` section
+13. Take a screenshot showing the success message and the users table in Available Tables
+
+14. Click the "Upload Data" button again to reopen the modal
+15. Click the "Product Inventory" sample button (`[data-sample="products"]`)
+16. Wait for the modal to close and for a `.success-message` to appear
+17. **Verify** the upload modal is hidden
+18. **Verify** a `.success-message` is displayed containing "products" and "created successfully"
+19. **Verify** "products" appears as a `.table-name` in the `#tables-list` section
+20. Take a screenshot showing the products table in Available Tables
+
+21. Click the "Upload Data" button again to reopen the modal
+22. Click the "Event Analytics" sample button (`[data-sample="events"]`)
+23. Wait for the modal to close and for a `.success-message` to appear
+24. **Verify** the upload modal is hidden
+25. **Verify** a `.success-message` is displayed containing "events" and "created successfully"
+26. **Verify** "events" appears as a `.table-name` in the `#tables-list` section
+27. **Verify** all three tables (users, products, events) are listed in `#tables-list`
+28. Take a screenshot showing all three tables in Available Tables
+
+## Success Criteria
+- Upload modal opens when "Upload Data" button is clicked
+- All three sample data buttons are present with correct labels
+- Clicking each sample button loads the dataset, closes the modal, and shows a success message
+- Each loaded table appears in the Available Tables section
+- All three tables coexist after loading all sample datasets
+- 5 screenshots are taken

--- a/app/client/src/main.ts
+++ b/app/client/src/main.ts
@@ -251,9 +251,14 @@ function displayTables(tables: TableSchema[]) {
     removeButton.title = 'Remove table';
     removeButton.onclick = () => removeTable(table.name);
 
+    const buttonGroup = document.createElement('div');
+    buttonGroup.style.display = 'flex';
+    buttonGroup.style.alignItems = 'center';
+    buttonGroup.appendChild(downloadButton);
+    buttonGroup.appendChild(removeButton);
+
     tableHeader.appendChild(tableLeft);
-    tableHeader.appendChild(downloadButton);
-    tableHeader.appendChild(removeButton);
+    tableHeader.appendChild(buttonGroup);
     
     // Columns section
     const tableColumns = document.createElement('div');

--- a/specs/issue-cfac6d55-adw-13-sdlc_planner-fix-csv-download-button-alignment.md
+++ b/specs/issue-cfac6d55-adw-13-sdlc_planner-fix-csv-download-button-alignment.md
@@ -1,0 +1,102 @@
+# Bug: CSV Download Button Misplaced in Table Header
+
+## Bug Description
+The download CSV button in the Available Tables section appears floating in the center of the table card header row instead of being grouped next to the remove (×) button on the right side. This is visually confusing because the two action buttons are not logically grouped together.
+
+**Expected behavior:** The download CSV button (↓) should appear immediately to the left of the remove (×) button, both flush to the right side of the table header.
+
+**Actual behavior:** With three direct flex children in `.table-header` (which uses `justify-content: space-between`), the download button lands in the horizontal center of the row — between the table name/info block on the left and the remove button on the far right.
+
+## Problem Statement
+The `.table-header` element uses `display: flex; justify-content: space-between`, which distributes its three direct children (tableLeft, downloadButton, removeButton) with maximum spacing. The download button ends up visually centered instead of grouped with the remove button.
+
+## Solution Statement
+Wrap the `downloadButton` and `removeButton` in a shared container `div` with `display: flex` and `align-items: center`. This makes both buttons a single flex child of `.table-header`, so `justify-content: space-between` places the left content block on the left and the button group on the right — with the two buttons side-by-side.
+
+## Steps to Reproduce
+1. Open the application at `http://localhost:5173`
+2. Click "Upload Data" and load any sample data (e.g. Products)
+3. Observe the Available Tables section
+4. Notice the download (↓) button appears in the middle of the table card header, not next to the remove (×) button
+
+## Root Cause Analysis
+In `app/client/src/main.ts`, inside `displayTables()`, three elements are appended as direct children of `tableHeader`:
+
+```js
+tableHeader.appendChild(tableLeft);      // flex child 1 (left)
+tableHeader.appendChild(downloadButton); // flex child 2 (center — BUG)
+tableHeader.appendChild(removeButton);   // flex child 3 (right)
+```
+
+`.table-header` CSS:
+```css
+.table-header {
+  display: flex;
+  justify-content: space-between;  /* pushes items to far ends + middle */
+  align-items: center;
+}
+```
+
+With `justify-content: space-between` and three children, the middle child (downloadButton) is placed at the horizontal center. The fix is to group `downloadButton` and `removeButton` into a single container so `.table-header` only has two flex children.
+
+## Relevant Files
+
+- **`app/client/src/main.ts`** — Contains `displayTables()` where `tableHeader` children are assembled. This is the only file that needs changing.
+- **`app/client/src/style.css`** — Contains `.table-header`, `.download-table-button`, and `.remove-table-button` styles. No changes required; the existing styles already render the buttons correctly in isolation.
+
+### New Files
+
+- **`.claude/commands/e2e/test_csv_download_alignment.md`** — New E2E test that validates the download button is visually grouped next to the remove button in the table header.
+
+## Step by Step Tasks
+
+### 1. Fix button grouping in `displayTables()` in `main.ts`
+
+- Open `app/client/src/main.ts`
+- Locate the `displayTables()` function (around line 208)
+- Find the block where `downloadButton` and `removeButton` are appended to `tableHeader`:
+  ```js
+  tableHeader.appendChild(tableLeft);
+  tableHeader.appendChild(downloadButton);
+  tableHeader.appendChild(removeButton);
+  ```
+- Wrap `downloadButton` and `removeButton` in a new container div:
+  ```js
+  const buttonGroup = document.createElement('div');
+  buttonGroup.style.display = 'flex';
+  buttonGroup.style.alignItems = 'center';
+  buttonGroup.appendChild(downloadButton);
+  buttonGroup.appendChild(removeButton);
+
+  tableHeader.appendChild(tableLeft);
+  tableHeader.appendChild(buttonGroup);
+  ```
+- Save the file
+
+### 2. Create E2E test for CSV download button alignment
+
+- Read `.claude/commands/test_e2e.md`, `.claude/commands/e2e/test_basic_query.md`, and `.claude/commands/e2e/test_csv_download.md` to understand the test file format
+- Create `.claude/commands/e2e/test_csv_download_alignment.md` that:
+  - Loads sample data (Products)
+  - Verifies a `.download-table-button` exists inside the `products` table card
+  - Verifies the download button and remove button are siblings within the same parent element (i.e. they share a common parent that is a child of `.table-header`)
+  - Alternatively, verifies via bounding box that the download button's right edge is adjacent to (immediately left of) the remove button's left edge
+  - Takes a screenshot of the table card header to visually confirm alignment
+  - Verifies the download button still works (triggers the download endpoint)
+
+### 3. Run validation commands
+
+- Execute all validation commands listed below to confirm zero regressions
+
+## Validation Commands
+
+- Read `.claude/commands/test_e2e.md`, then read and execute `.claude/commands/e2e/test_csv_download_alignment.md` to validate the alignment fix works
+- `cd app/server && uv run pytest` — Run server tests to validate the bug is fixed with zero regressions
+- `cd app/client && bun tsc --noEmit` — Run frontend type check to validate the bug is fixed with zero regressions
+- `cd app/client && bun run build` — Run frontend build to validate the bug is fixed with zero regressions
+
+## Notes
+
+- The fix is a minimal one-function change in `main.ts` — no CSS changes needed
+- The existing `.download-table-button` styles already include proper sizing (`width: 2rem; height: 2rem; display: flex; align-items: center; justify-content: center`) so no new CSS is required
+- The existing `test_csv_download.md` E2E test verifies download functionality; the new test focuses on layout/alignment correctness


### PR DESCRIPTION
## Summary

Fixes the misaligned CSV download button in the results table header. The button was not positioned correctly relative to the Remove Table button.

**Issue:** [#13 - Bug: download csv button misplaced](https://github.com/agent-simon/tac5/issues/13)

## Implementation Plan

See: `specs/issue-cfac6d55-adw-13-sdlc_planner-fix-csv-download-button-alignment.md`

## Changes Made

- [x] Aligned CSV download button next to the Remove Table button in the results header
- [x] Created implementation plan for the fix
- [x] Added E2E test for sample data loading

## Key Changes

- `specs/issue-cfac6d55-adw-13-sdlc_planner-fix-csv-download-button-alignment.md` — Implementation plan documenting the fix approach
- `.claude/commands/e2e/test_sample_data_loading.md` — New E2E test command for sample data loading

---

Closes #13

> ADW tracking ID: cfac6d55